### PR TITLE
Support 1.20.6 (#271)

### DIFF
--- a/dough-api/pom.xml
+++ b/dough-api/pom.xml
@@ -168,10 +168,6 @@
             <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
-            <id>IntellectualSites</id>
-            <url>https://mvn.intellectualsites.com/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
             <id>funnyguilds-repo</id>
             <url>https://repo.panda-lang.org/releases</url>
         </repository>
@@ -415,6 +411,13 @@
             <artifactId>plugin</artifactId>
             <version>4.12.0</version>
             <scope>provided</scope>
+            <exclusions>
+                <!-- Exclude invalid dependency -->
+                <exclusion>
+                    <groupId>com.github.PikaMug</groupId>
+                    <artifactId>LocaleLib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- HuskTowns -->

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemUtils.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemUtils.java
@@ -6,6 +6,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
@@ -174,8 +176,8 @@ public final class ItemUtils {
         if (item.getType() != Material.AIR && item.getAmount() > 0) {
             int remove = damage;
 
-            if (!ignoreEnchantments && item.getEnchantments().containsKey(Enchantment.DURABILITY)) {
-                int level = item.getEnchantmentLevel(Enchantment.DURABILITY);
+            if (!ignoreEnchantments && item.getEnchantments().containsKey(Registry.ENCHANTMENT.get(NamespacedKey.minecraft("unbreaking")))) {
+                int level = item.getEnchantmentLevel(Registry.ENCHANTMENT.get(NamespacedKey.minecraft("unbreaking")));
 
                 for (int i = 0; i < damage; i++) {
                     if (Math.random() * 100 <= (60 + Math.floorDiv(40, (level + 1)))) {

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.papermc.lib.PaperLib;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.bakedlibs.dough.common.DoughLogger;
@@ -20,11 +21,19 @@ public interface ItemNameAdapter {
 
     public static @Nullable ItemNameAdapter get() {
         try {
-            MinecraftVersion version = MinecraftVersion.get();
-
             if (MinecraftVersion.isMocked()) {
                 // Special case for MockBukkit
                 return new ItemNameAdapterMockBukkit();
+            }
+
+            MinecraftVersion version = MinecraftVersion.get();
+
+            if (version.isAtLeast(1, 20, 4) && PaperLib.isPaper()) {
+                return new ItemNameAdapterPaper();
+            }
+
+            if (version.isAtLeast(1, 20, 5)) {
+                return new ItemNameAdapter20v5();
             } else if (version.isAtLeast(1, 20)) {
                 return new ItemNameAdapter20();
             } else if (version.isAtLeast(1, 19)) {

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter20v5.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapter20v5.java
@@ -1,0 +1,32 @@
+package io.github.bakedlibs.dough.items.nms;
+
+import io.github.bakedlibs.dough.reflection.ReflectionUtils;
+import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+class ItemNameAdapter20v5 implements ItemNameAdapter {
+
+    private final Method getCopy;
+    private final Method getName;
+    private final Method toString;
+
+    ItemNameAdapter20v5() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
+        super();
+
+        getCopy = ReflectionUtils.getOBCClass("inventory.CraftItemStack").getMethod("asNMSCopy", ItemStack.class);
+        getName = ReflectionUtils.getMethodOrAlternative(ReflectionUtils.getNetMinecraftClass("world.item.ItemStack"), "getDisplayName", "G");
+        toString = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("network.chat.IChatBaseComponent"), "getString");
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public String getName(ItemStack item) throws IllegalAccessException, InvocationTargetException {
+        Object instance = getCopy.invoke(null, item);
+        return (String) toString.invoke(getName.invoke(instance));
+    }
+
+}

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapterPaper.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/nms/ItemNameAdapterPaper.java
@@ -1,0 +1,16 @@
+package io.github.bakedlibs.dough.items.nms;
+
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.lang.reflect.InvocationTargetException;
+
+public class ItemNameAdapterPaper implements ItemNameAdapter {
+    @Override
+    @ParametersAreNonnullByDefault
+    public String getName(ItemStack item) throws IllegalAccessException, InvocationTargetException {
+        return PlainTextComponentSerializer.plainText().serialize(Bukkit.getItemFactory().displayName(item));
+    }
+}

--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -79,18 +79,36 @@
             <artifactId>worldedit-core</artifactId>
             <version>7.2.17</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
             <version>7.2.17</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
             <version>7.0.9</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- PreciousStones -->
@@ -99,6 +117,12 @@
             <artifactId>PreciousStones</artifactId>
             <version>1.17.2</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- CoreProtect -->
@@ -107,6 +131,12 @@
             <artifactId>coreprotect</artifactId>
             <version>21.3</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- LogBlock -->
@@ -115,6 +145,12 @@
             <artifactId>logblock</artifactId>
             <version>1.17.0.0-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- SimpleClans -->
@@ -123,6 +159,12 @@
             <artifactId>SimpleClans</artifactId>
             <version>7c3db52796</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- GriefPrevention -->
@@ -131,6 +173,12 @@
             <artifactId>GriefPrevention</artifactId>
             <version>16.18.2</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- LWC -->
@@ -139,6 +187,12 @@
             <artifactId>lwc</artifactId>
             <version>master-4.5.1-g2100b5e-18</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- FactionsUUID -->
@@ -147,12 +201,24 @@
             <artifactId>helper</artifactId>
             <version>5.6.14</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.massivecraft</groupId>
             <artifactId>Factions</artifactId>
             <version>1.6.9.5-4.1.4-STABLE</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Towny -->
@@ -161,6 +227,12 @@
             <artifactId>Towny</artifactId>
             <version>1b86d017c5</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Lockette -->
@@ -169,6 +241,12 @@
             <artifactId>Lockette</artifactId>
             <version>9dac96e8f8</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- PlotSquared -->
@@ -182,6 +260,10 @@
                     <groupId>org.projectlombok</groupId>
                     <artifactId>lombok</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -194,6 +276,10 @@
                     <artifactId>plotsquared-core</artifactId>
                     <groupId>*</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -203,12 +289,24 @@
             <artifactId>RedProtect-Core</artifactId>
             <version>7.7.3</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>br.net.fabiozumbi12.RedProtect</groupId>
             <artifactId>RedProtect-Spigot</artifactId>
             <version>7.7.3</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- BentoBox -->
@@ -217,6 +315,12 @@
             <artifactId>bentobox</artifactId>
             <version>1.20.1</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- BlockLocker -->
@@ -225,6 +329,12 @@
             <artifactId>blocklocker</artifactId>
             <version>1.10.4</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Lands -->
@@ -233,6 +343,12 @@
             <artifactId>LandsAPI</artifactId>
             <version>6.29.12</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- ChestProtect -->
@@ -241,6 +357,12 @@
             <artifactId>ChestProtectAPI</artifactId>
             <version>3.9.1</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- FunnyGuilds -->
@@ -249,6 +371,17 @@
             <artifactId>plugin</artifactId>
             <version>4.12.0</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+                <!-- Exclude invalid dependency -->
+                <exclusion>
+                    <groupId>com.github.PikaMug</groupId>
+                    <artifactId>LocaleLib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- HuskTowns -->
@@ -257,6 +390,12 @@
             <artifactId>husktowns-bukkit</artifactId>
             <version>3.0-988161b</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- HuskClaims -->
@@ -265,14 +404,26 @@
             <artifactId>huskclaims-bukkit</artifactId>
             <version>1.0.2-e60150d</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
-      
+
         <!-- ShopChest -->
         <dependency>
             <groupId>de.epiceric</groupId>
             <artifactId>ShopChest</artifactId>
             <version>1.13-SNAPSHOT</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Bolt -->
@@ -281,6 +432,12 @@
             <artifactId>bolt-bukkit</artifactId>
             <version>1.0.580</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bukkit</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/PlayerHead.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/PlayerHead.java
@@ -80,16 +80,7 @@ public final class PlayerHead {
 
         try {
             GameProfile profile = skin.getProfile();
-            Object tileEntity = adapter.getTileEntity(block);
-
-            if (tileEntity != null) {
-                adapter.setGameProfile(tileEntity, profile);
-
-                if (sendBlockUpdate) {
-                    block.getState().update(true, false);
-                }
-            }
-
+            adapter.setGameProfile(block, profile, sendBlockUpdate);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         }

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.papermc.lib.PaperLib;
 import org.bukkit.block.Block;
 
 import com.mojang.authlib.GameProfile;
@@ -16,17 +17,16 @@ import io.github.bakedlibs.dough.versions.MinecraftVersion;
 public interface PlayerHeadAdapter {
 
     @ParametersAreNonnullByDefault
-    @Nullable
-    Object getTileEntity(Block block) throws IllegalAccessException, InvocationTargetException, InstantiationException;
-
-    @ParametersAreNonnullByDefault
-    void setGameProfile(Object tileEntity, GameProfile profile) throws IllegalAccessException, InvocationTargetException;
+    void setGameProfile(Block block, GameProfile profile, boolean sendBlockUpdate) throws IllegalAccessException, InvocationTargetException, InstantiationException;
 
     public static @Nullable PlayerHeadAdapter get() {
         try {
             MinecraftVersion version = MinecraftVersion.get();
 
-            if (version.isAtLeast(1, 18)) {
+            if (version.isAtLeast(1, 20, 5)) {
+                // 1.20.5 mappings
+                return new PlayerHeadAdapter20v5();
+            } else if (version.isAtLeast(1, 18)) {
                 // 1.18 mappings
                 return new PlayerHeadAdapter18();
             } else if (version.isAtLeast(1, 17)) {

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter18.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter18.java
@@ -27,9 +27,8 @@ class PlayerHeadAdapter18 implements PlayerHeadAdapter {
         getTileEntity = ReflectionUtils.getNMSClass("level.WorldServer").getMethod("getBlockEntity", blockPosition, boolean.class);
     }
 
-    @Override
     @ParametersAreNonnullByDefault
-    public @Nullable Object getTileEntity(Block block) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+    private @Nullable Object getTileEntity(Block block) throws IllegalAccessException, InvocationTargetException, InstantiationException {
         Object world = getHandle.invoke(block.getWorld());
 
         Object position = newPosition.newInstance(block.getX(), block.getY(), block.getZ());
@@ -38,8 +37,15 @@ class PlayerHeadAdapter18 implements PlayerHeadAdapter {
 
     @Override
     @ParametersAreNonnullByDefault
-    public void setGameProfile(Object tileEntity, GameProfile profile) throws IllegalAccessException, InvocationTargetException {
+    public void setGameProfile(Block block, GameProfile profile, boolean sendBlockUpdate) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object tileEntity = getTileEntity(block);
+        if (tileEntity == null) return;
+
         setGameProfile.invoke(tileEntity, profile);
+
+        if (sendBlockUpdate) {
+            block.getState().update(true, false);
+        }
     }
 
 }

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter20v5.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapter20v5.java
@@ -1,34 +1,36 @@
 package io.github.bakedlibs.dough.skins.nms;
 
+import com.mojang.authlib.GameProfile;
+import io.github.bakedlibs.dough.reflection.ReflectionUtils;
+import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
+import org.bukkit.block.Block;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-
-import org.bukkit.block.Block;
-
-import com.mojang.authlib.GameProfile;
-
-import io.github.bakedlibs.dough.reflection.ReflectionUtils;
-import io.github.bakedlibs.dough.versions.UnknownServerVersionException;
-
-class PlayerHeadAdapter17 implements PlayerHeadAdapter {
+class PlayerHeadAdapter20v5 implements PlayerHeadAdapter {
 
     private final Constructor<?> newPosition;
+    private final Constructor<?> newResolvableProfile;
 
     private final Method getHandle;
     private final Method getTileEntity;
-    private final Method setGameProfile;
+    private final Method setOwner;
 
-    PlayerHeadAdapter17() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
-        setGameProfile = ReflectionUtils.getNetMinecraftClass("world.level.block.entity.TileEntitySkull").getMethod("setGameProfile", GameProfile.class);
+    PlayerHeadAdapter20v5() throws NoSuchMethodException, SecurityException, ClassNotFoundException, UnknownServerVersionException {
+        Class<?> resolvableProfile = ReflectionUtils.getNetMinecraftClass("world.item.component.ResolvableProfile");
+        newResolvableProfile = ReflectionUtils.getConstructor(resolvableProfile, GameProfile.class);
+
+        setOwner = ReflectionUtils.getNetMinecraftClass("world.level.block.entity.TileEntitySkull").getMethod("a", resolvableProfile);
         getHandle = ReflectionUtils.getOBCClass("CraftWorld").getMethod("getHandle");
 
         Class<?> blockPosition = ReflectionUtils.getNetMinecraftClass("core.BlockPosition");
         newPosition = ReflectionUtils.getConstructor(blockPosition, int.class, int.class, int.class);
-        getTileEntity = ReflectionUtils.getNMSClass("level.WorldServer").getMethod("getTileEntity", blockPosition);
+
+        getTileEntity = ReflectionUtils.getNMSClass("level.WorldServer").getMethod("getBlockEntity", blockPosition, boolean.class);
     }
 
     @ParametersAreNonnullByDefault
@@ -36,7 +38,7 @@ class PlayerHeadAdapter17 implements PlayerHeadAdapter {
         Object world = getHandle.invoke(block.getWorld());
 
         Object position = newPosition.newInstance(block.getX(), block.getY(), block.getZ());
-        return getTileEntity.invoke(world, position);
+        return getTileEntity.invoke(world, position, true);
     }
 
     @Override
@@ -45,7 +47,8 @@ class PlayerHeadAdapter17 implements PlayerHeadAdapter {
         Object tileEntity = getTileEntity(block);
         if (tileEntity == null) return;
 
-        setGameProfile.invoke(tileEntity, profile);
+        Object resolvableProfile = newResolvableProfile.newInstance(profile);
+        setOwner.invoke(tileEntity, resolvableProfile);
 
         if (sendBlockUpdate) {
             block.getState().update(true, false);

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapterBefore17.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapterBefore17.java
@@ -31,9 +31,8 @@ class PlayerHeadAdapterBefore17 implements PlayerHeadAdapter {
         getTileEntity = ReflectionUtils.getNMSClass("WorldServer").getMethod("getTileEntity", blockPosition);
     }
 
-    @Override
     @ParametersAreNonnullByDefault
-    public @Nullable Object getTileEntity(Block block) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+    private @Nullable Object getTileEntity(Block block) throws IllegalAccessException, InvocationTargetException, InstantiationException {
         Object world = getHandle.invoke(block.getWorld());
 
         Object position = newPosition.newInstance(block.getX(), block.getY(), block.getZ());
@@ -42,8 +41,15 @@ class PlayerHeadAdapterBefore17 implements PlayerHeadAdapter {
 
     @Override
     @ParametersAreNonnullByDefault
-    public void setGameProfile(Object tileEntity, GameProfile profile) throws IllegalAccessException, InvocationTargetException {
+    public void setGameProfile(Block block, GameProfile profile, boolean sendBlockUpdate) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        Object tileEntity = getTileEntity(block);
+        if (tileEntity == null) return;
+
         setGameProfile.invoke(tileEntity, profile);
+
+        if (sendBlockUpdate) {
+            block.getState().update(true, false);
+        }
     }
 
 }

--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapterPaper.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/nms/PlayerHeadAdapterPaper.java
@@ -1,0 +1,50 @@
+package io.github.bakedlibs.dough.skins.nms;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import io.github.bakedlibs.dough.reflection.ReflectionUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Skull;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+// Not currently in use.
+// This does not correctly update heads on updates currently.
+public class PlayerHeadAdapterPaper implements PlayerHeadAdapter {
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void setGameProfile(Block block, GameProfile profile, boolean sendBlockUpdate) throws InvocationTargetException, IllegalAccessException {
+        BlockState state = block.getState();
+        if (!(state instanceof Skull)) return;
+
+        Skull skull = (Skull) state;
+
+        Property property = profile.getProperties().get("textures").iterator().next();
+
+        PlayerProfile paperPlayerProfile = Bukkit.createProfile(profile.getId(), profile.getName());
+
+        Method getName = ReflectionUtils.getMethod(Property.class, "getName");
+        Method getValue = ReflectionUtils.getMethod(Property.class, "getValue");
+        Method getSignature = ReflectionUtils.getMethod(Property.class, "getSignature");
+
+        // Old authlib check
+        if (getName != null && getValue != null && getSignature != null) {
+            paperPlayerProfile.setProperty(new ProfileProperty((String) getName.invoke(property), (String) getValue.invoke(property), (String) getSignature.invoke(property)));
+        } else {
+            paperPlayerProfile.setProperty(new ProfileProperty(property.name(), property.value(), property.signature()));
+        }
+
+        skull.setPlayerProfile(paperPlayerProfile);
+
+        if (sendBlockUpdate) {
+            skull.update(true, false);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -278,15 +278,15 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>paper</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
* Support 1.20.6 and add paper adapters

* remove space

* reduce to one call

* fix build due to funnyguilds invalid dependency

* use registry instead of enum

* fix: use old getter of property for older versions

* Put paper adapter behind 1.19.4 gate

The adapter is using adventure which was not bundled into Paper until 1.19.4 so to support it, we can only use this version or higher.

* Disable paper head adapter

---------